### PR TITLE
Openshift ip port order swap

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,8 @@ app.set(
 // Server Port
 app.set(
   'port'
-, process.env.OPENSHIFT_NODEJS_PORT
-  || process.env.PORT
+, process.env.PORT
+  || process.env.OPENSHIFT_NODEJS_PORT
   || '3000'
 );
 

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ var consolidate = require('consolidate');
 // Server IP
 app.set(
   'ip'
-, process.env.OPENSHIFT_NODEJS_IP
-  || process.env.IP
+, process.env.IP
+  || process.env.OPENSHIFT_NODEJS_IP
   || '0.0.0.0'
 );
 


### PR DESCRIPTION
:beetle: Swapped sort-circuiting assignment of ip and port, between OPENSHIFT_NODEJS_IP and IP, and OPENSHIFT_NODEJS_PORT and PORT. Such that the server will attempt to listen to IP and PORT environment variables first.
